### PR TITLE
Options for renaming filenames using product_title, creating directories based on bundle subtitles, additional allowed_chars

### DIFF
--- a/humblebundle_downloader/cli.py
+++ b/humblebundle_downloader/cli.py
@@ -86,7 +86,17 @@ def cli():
         help=("The purchase download key. Find in the url on the "
               "products/bundle download page. Can set multiple"),
     )
-
+    parser_download.add_argument(
+        '-f', '--human-filenames',
+        action='store_true',
+        help="Filenames are renamed to match product title",
+    )
+    parser_download.add_argument(
+        '-s', '--sub-bundle-title',
+        action='store_true',
+        help=("If bundle has a sub-title, create a directory base on subtitle."
+              "Ex: Humble Book Bundle: Read Books, /Humble Book Bundle/Read Books")
+    )
     cli_args = parser.parse_args()
 
     if cli_args.action == 'gen-cookies':
@@ -105,4 +115,6 @@ def cli():
             purchase_keys=cli_args.keys,
             trove=cli_args.trove,
             update=cli_args.update,
+            human_filenames=cli_args.human_filenames,
+            sub_title=cli_args.sub_bundle_title,
         ).start()

--- a/humblebundle_downloader/download_library.py
+++ b/humblebundle_downloader/download_library.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def _clean_name(dirty_str):
     allowed_chars = (' ', '_', '.', '-', '+', '(', ')', '[', ']', '\'', ',', '#', '&')
     clean = []
-    for c in dirty_str.replace('/', '-').replace(' : ', ' - ').replace(': ', ' - ').replace(' :', ' - ').replace(':', '-').replace('*', '-').replace('"', '\'').replace('<', '(').replace('>', ')').replace('|', '-'):
+    for c in dirty_str.replace('/', '-').replace(' : ', ' - ').replace(': ', ' - ').replace(' :', ' - ').replace(':', '-').replace('*', '-').replace('"', '\'').replace('<', '(').replace('>', ')').replace('|', '-').replace('’', '\''):
         if c.isalpha() or c.isdigit() or c in allowed_chars:
             clean.append(c)
 
@@ -196,10 +196,11 @@ class DownloadLibrary:
 
         logger.debug("Order request: {order_r}".format(order_r=order_r))
         order = order_r.json()
-        bundle_title_parts = order['product']['human_name'].split(': ',1)
+        bundle_title_base = order['product']['human_name']
+        bundle_title_parts = bundle_title_base.split(': ',1)
         bundle_title = _clean_name(bundle_title_parts[0])
-        bundle_title_sub = _clean_name(bundle_title_parts[1]) if self.sub_title and (":" in order['product']['human_name']) else ""
-        logger.info("Checking bundle: " + str(bundle_title))
+        bundle_title_sub = _clean_name(bundle_title_parts[1]) if self.sub_title and (":" in bundle_title_base) else ""
+        logger.info("Checking bundle: " + str(bundle_title_base))
         for product in order['subproducts']:
             self._process_product(order_id, bundle_title, bundle_title_sub, product)
 

--- a/humblebundle_downloader/download_library.py
+++ b/humblebundle_downloader/download_library.py
@@ -11,9 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 def _clean_name(dirty_str):
-    allowed_chars = (' ', '_', '.', '-', '[', ']', ',', '#', '&')
+    allowed_chars = (' ', '_', '.', '-', '+', '(', ')', '[', ']', '\'', ',', '#', '&')
     clean = []
-    for c in dirty_str.replace('+', '_').replace(':', ' -'):
+    for c in dirty_str.replace('/', '-').replace(' : ', ' - ').replace(': ', ' - ').replace(' :', ' - ').replace(':', '-').replace('*', '-').replace('"', '\'').replace('<', '(').replace('>', ')').replace('|', '-'):
         if c.isalpha() or c.isdigit() or c in allowed_chars:
             clean.append(c)
 
@@ -196,7 +196,7 @@ class DownloadLibrary:
 
         logger.debug("Order request: {order_r}".format(order_r=order_r))
         order = order_r.json()
-        bundle_title_parts = order['product']['human_name'].rsplit(': ',1)
+        bundle_title_parts = order['product']['human_name'].split(': ',1)
         bundle_title = _clean_name(bundle_title_parts[0])
         bundle_title_sub = _clean_name(bundle_title_parts[1]) if self.sub_title and (":" in order['product']['human_name']) else ""
         logger.info("Checking bundle: " + str(bundle_title))


### PR DESCRIPTION
I find the downloaded filenames to sometimes be really esoteric (especially on the 3D printer bundles, but even the Book bundles can be difficult at times), copying all the files into sub-directories based on product_title really helps, but sometimes when I'm pulling PDFs onto my phone it's really helpful to use product_title for the filenames as well. So I added an option -f/--human_filenames that will use the product_title for the filenames.

Also I liked to group my downloaded bundles (well mostly the Book bundles) by bundle type, or bundle sub-title, so that "Humble Book Bundle: Fun with STEM by Adams Media" becomes "Humble Book Bundle/Fun with STEM by Adams Media" instead of "Humble Book Bundle - Fun with STEM by Adams Media". So I added an option -s/--sub-title that will control that.

The list of allowed characters seemed a little short, especially with with say the C# book bundles, so I added in some more allowed characters.

Added option to split bundle title into title and sub-title and create directories as such, ex Humble Book Bundle: Fun with STEM by Adams Media => Humble Book Bundle/Fun with STEM by Adams Media instead of Humble Book Bundle - Fun with STEM by Adams Media
Added additional allowed_chars , # and &