### PR TITLE
Download Trove games with no 'uploaded_at' field. Fixes xtream1101#23

### DIFF
--- a/humblebundle_downloader/download_library.py
+++ b/humblebundle_downloader/download_library.py
@@ -114,8 +114,8 @@ class DownloadLibrary:
 
             cache_file_key = 'trove:{name}'.format(name=web_name)
             file_info = {
-                'uploaded_at': download.get('uploaded_at'),
-                'md5': download.get('md5'),
+                'uploaded_at': download.get('uploaded_at') or download.get('timestamp') or product.get('date_added', '0'),
+                'md5': download.get('md5', 'UNKNOWN_MD5'),
             }
             cache_file_info = self.cache_data.get(cache_file_key, {})
 


### PR DESCRIPTION
#23 is caused by Humble not including 'uploaded_at' values with every game. Because this, both the "cached" value and the retrieved value for `uploaded_at` will be `None` on line 126, so it's erroneously skipped.