### PR TITLE
Fix crash if no arguments are passed to CLI

### DIFF
--- a/humblebundle_downloader/cli.py
+++ b/humblebundle_downloader/cli.py
@@ -15,7 +15,7 @@ logging.getLogger('urllib3.connectionpool').setLevel(logging.WARNING)
 
 
 def parse_args(args):
-    if args[0].lower() == 'download':
+    if len(args) > 0 and args[0].lower() == 'download':
         args = args[1:]
         raise DeprecationWarning("`download` argument is no longer used")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,3 +11,9 @@ def test_no_action():
     args = parse_args(['-l', 'some_path', '-c', 'fake_cookie'])
     assert args.library_path == 'some_path'
     assert args.cookie_file == 'fake_cookie'
+
+
+def test_no_args():
+    with pytest.raises(SystemExit) as ex:
+        parse_args([])
+    assert ex.value.code == 2


### PR DESCRIPTION
Invoking `hbd` without any arguments results in a crash:
```
$ hbd
Traceback (most recent call last):
  File "/home/shane/.local/bin/hbd", line 8, in <module>
    sys.exit(cli())
  File "/home/shane/.local/lib/python3.9/site-packages/humblebundle_downloader/cli.py", line 81, in cli
    cli_args = parse_args(sys.argv[1:])
  File "/home/shane/.local/lib/python3.9/site-packages/humblebundle_downloader/cli.py", line 18, in parse_args
    if args[0].lower() == 'download':
IndexError: list index out of range
```

This PR should fix that. It's a simple 1-line fix. Also included is a test.