### PR TITLE
Suggested changes to avoid users subjecting themselves to data leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ First thing to do is get your account cookies. This can be done by getting a bro
 
 ### 2. Downloading your library
 Use the following command to download your Humble Bundle Library:  
-`hbd --cookie-file cookies.txt --library-path "Downloaded Library" --progress`  
+`export HISTCONTROL=ignorespace
+ hbd -s "<COOKIE_VALUE>" --library-path "Downloaded Library" --progress
+ unset HISTCONTROL`
 
 This directory structure will be used:  
 `Downloaded Library/Purchase Name/Item Name/downloaded_file.ext`


### PR DESCRIPTION
I reason that if someone already has a specialized HISTCONTROL, then there is little need to tell them not to override it.